### PR TITLE
modify type gen

### DIFF
--- a/.changeset/chubby-geese-knock.md
+++ b/.changeset/chubby-geese-knock.md
@@ -1,0 +1,5 @@
+---
+"typed-rest-routes": patch
+---
+
+Modify typed route generation to automatically get the astro project root instead of relying on relative path

--- a/playground/package.json
+++ b/playground/package.json
@@ -1,5 +1,6 @@
 {
   "name": "playground",
+  "private": true,
   "type": "module",
   "version": "0.0.1",
   "scripts": {


### PR DESCRIPTION
Updates type gen to automatically resolve the path to the root of the astro project, instead of relying on relative imports.